### PR TITLE
docs: add install script usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ pnpm docs:build
 
 TurboRepo docs: `https://turborepo.com/docs`
 
+### Install connectors (optional)
+
+Use the install script to quickly set up connectors, or just copy the code directly from the registry:
+
+```bash
+# List available connectors
+./install.sh --list
+
+# Install a specific connector (connector, version, author, language)
+./install.sh google-analytics v4 fiveonefour typescript
+```
+
 ### Philosophy (shadcn‑inspired)
 
 We are not a hosted connector product. We’re a system you copy into your repo:


### PR DESCRIPTION
* Added a new "Install connectors (optional)" section to `README.md`, including usage instructions and example commands for the `install.sh` script to list and install connectors.